### PR TITLE
remove wire transfer approval single operation key info

### DIFF
--- a/06. Movimentação de contas/6.2 Transferências.md
+++ b/06. Movimentação de contas/6.2 Transferências.md
@@ -98,31 +98,13 @@ Exemplo:
 
 Para transferências partindo de contas escrow é necessária a aprovação
 da mesma (por um agente que consta no contrato) antes de sua efetivação.
-O body desta request aceita uma lista de operações ou uma única operação.
+O body desta request aceita uma lista de operações.
 
 - endpoint: /wire_transfer_approval
 - method: POST
 <br>
 
-#### Body para uma única operação:
-
-```json
-{
-	"operation_key": "0e241203-8c6b-4e0a-ac42-e0d2a2fc2d37",
-	"feedback": true
-}
-```
-
-##### Atributos de uma aprovação de transferência única
-
-| Campo | Descrição | Exemplo |
-|---|---|---|
-| **`operation_key`** *(obrigatório)* | Chave entregue quando a transferência foi criada (parâmetro key da resposta) | "0e241203-8c6b-4e0a-ac42-e0d2a2fc2d37" |
-| **`feedback`** *(obrigatório)* | Booleano de aprovação ou rejeição da transferência: "true" ou "false" | "true" |
-
-<br>
-
-#### Body para uma lista de operações:
+#### Body:
 
 ```json
 {


### PR DESCRIPTION
Remove wire transfer approval instructions for single operation key field in json.